### PR TITLE
display top margin borders

### DIFF
--- a/src/gitbook-azure.css
+++ b/src/gitbook-azure.css
@@ -1009,7 +1009,7 @@ footer.ty-footer {
 } /* adds dark borders below top margin */
 
 .mac-seamless-mode content {
-    margin-top: unset;
+    border-top: solid 1px transparent;
 } /* don't show top margin border in seamless mode */
 
 .info-panel-tab {

--- a/src/gitbook-azure.css
+++ b/src/gitbook-azure.css
@@ -22,6 +22,7 @@
     --meta-content-color: #3884ff;
 
     --borders: #e6ecf1;
+    --borders-top-margin: #E5E5E5; /* for dark borders below top margin */
     --table-border-color: #e6ecf1;
     --boxes: #f5f7f9;
     --boxes-darker: #d8e0e7;
@@ -1002,6 +1003,14 @@ footer.ty-footer {
 #typora-sidebar {
     border-right: solid 1px var(--borders);
 }
+
+#typora-sidebar, #typora-sidebar-resizer, content {
+    border-top: solid 1px var(--borders-top-margin);
+} /* adds dark borders below top margin */
+
+.mac-seamless-mode content {
+    margin-top: unset;
+} /* don't show top margin border in seamless mode */
 
 .info-panel-tab {
     opacity: 1;

--- a/src/gitbook-slate.css
+++ b/src/gitbook-slate.css
@@ -940,6 +940,14 @@ input[type="checkbox"]:checked:after {
     border-right: solid 1px var(--borders);
 }
 
+#typora-sidebar, #typora-sidebar-resizer, content {
+    border-top: solid 1px var(--borders-top-margin);
+} /* adds dark borders below top margin */
+
+.mac-seamless-mode content {
+    margin-top: unset;
+} /* don't show top margin border in seamless mode */
+
 .info-panel-tab {
     opacity: 1;
 }

--- a/src/gitbook-slate.css
+++ b/src/gitbook-slate.css
@@ -945,7 +945,7 @@ input[type="checkbox"]:checked:after {
 } /* adds dark borders below top margin */
 
 .mac-seamless-mode content {
-    margin-top: unset;
+    border-top: solid 1px transparent;
 } /* don't show top margin border in seamless mode */
 
 .info-panel-tab {

--- a/src/gitbook-teal.css
+++ b/src/gitbook-teal.css
@@ -22,6 +22,7 @@
     --meta-content-color: #15ac8e;
 
     --borders: #e6ecf1;
+    --borders-top-margin: #E5E5E5; /* for dark borders below top margin */
     --table-border-color: #e6ecf1;
     --boxes: #f5f7f9;
     --boxes-darker: #d8e0e7;
@@ -1000,6 +1001,14 @@ footer.ty-footer {
 #typora-sidebar {
     border-right: solid 1px var(--borders);
 }
+
+#typora-sidebar, #typora-sidebar-resizer, content {
+    border-top: solid 1px var(--borders-top-margin);
+} /* adds dark borders below top margin */
+
+.mac-seamless-mode content {
+    margin-top: unset;
+} /* don't show top margin border in seamless mode */
 
 .info-panel-tab {
     opacity: 1;

--- a/src/gitbook-teal.css
+++ b/src/gitbook-teal.css
@@ -1007,7 +1007,7 @@ footer.ty-footer {
 } /* adds dark borders below top margin */
 
 .mac-seamless-mode content {
-    margin-top: unset;
+    border-top: solid 1px transparent;
 } /* don't show top margin border in seamless mode */
 
 .info-panel-tab {

--- a/src/gitbook/slate-colors.css
+++ b/src/gitbook/slate-colors.css
@@ -20,6 +20,7 @@
     --meta-content-color: #3783ff;
 
     --borders: #272c35;
+    --borders-top-margin: #07080A; /* for dark borders below top margin */
     --table-border-color: #272c35;
     --boxes: #1c2027;
     --boxes-darker: #353b46;

--- a/src/gitbook/slate-colors.css
+++ b/src/gitbook/slate-colors.css
@@ -20,7 +20,7 @@
     --meta-content-color: #3783ff;
 
     --borders: #272c35;
-    --borders-top-margin: #07080A; /* for dark borders below top margin */
+    --borders-top-margin: #0A0C0E; /* for dark borders below top margin */
     --table-border-color: #272c35;
     --boxes: #1c2027;
     --boxes-darker: #353b46;


### PR DESCRIPTION
@h16nning hi again

glad I could help last time 👍 
I use the azure/slate themes for lesson plans, love them

on that note, I noticed that tabs may be a little unsightly at times
for example:
| azure | slate |
| - | - |
| <img width="1214" alt="azure_tabs_2" src="https://user-images.githubusercontent.com/63764270/206101573-23459570-32fe-40ce-95d7-161860b20098.png"> | <img width="1214" alt="slate_tabs_2" src="https://user-images.githubusercontent.com/63764270/206101669-1c713a0e-dca2-4c0a-a150-33cf322aaced.png"> |

you are welcome to try these:
| azure | slate |
| - | - |
| <img width="1214" alt="azure_tabs_2_new" src="https://user-images.githubusercontent.com/63764270/206101580-edbdd291-0616-4912-a575-df2a6da460fa.png"> | <img width="1214" alt="slate_tabs_2_new" src="https://user-images.githubusercontent.com/63764270/206101674-7a59e0c6-2d5f-4488-ad70-0d5813d6e1da.png"> |

background: to get the border colors, I changed the window style to classic, and then used macos' digital color meter to get the border color right above the sidebar
...the border color right above the content element could work, too, but it might be too light for the sidebar

